### PR TITLE
ci: add dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+- package-ecosystem: gitsubmodule
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 99
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 99


### PR DESCRIPTION
This PR adds a dependabot configuration file. Dependabot is a built-in service from GitHub which will create PRs for updating GitHub Actions.

It seems that this repo used dependabot-preview, which was disabled some months ago (see #327). That's because dependabot was an external service which GitHub bought and made it a built-in feature.

Close #326
Close #327
Close #332
Close #270