### PR TITLE
Fix CI that generates the result page

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY_FILE }}
 


### PR DESCRIPTION
Pinned setup-gcloud action to version "v0", fixes the GCS URL link