### PR TITLE
ci: limit concurrency

### DIFF
--- a/.github/workflows/Automerge.yml
+++ b/.github/workflows/Automerge.yml
@@ -1,5 +1,9 @@
 name: Automerge
 
+concurrency:
+  group: ${{ github.repository }}-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
This allows new CI runs to automatically cancel the previous runs corresponding to the same branch. CI is still expected to fail.