### PR TITLE
infrastructure/runner: no tqdm

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -12,7 +12,6 @@ requests
 simplejson
 termcolor
 terminaltables
-tqdm
 yapf==0.31.0
 git+https://github.com/SymbiFlow/edalize.git@symbiflow_update#egg=edalize
 https://github.com/chipsalliance/f4pga/archive/de9ed1f3dba34d641c354bdb070232887254b142.zip#subdirectory=f4pga

--- a/infrastructure/runner.py
+++ b/infrastructure/runner.py
@@ -20,7 +20,6 @@
 import datetime
 import os
 import sys
-import tqdm
 import glob
 import gzip
 import json
@@ -95,9 +94,7 @@ class Runner:
         print('Writing to %s' % self.out_prefix)
 
         with Pool(self.num_cpu) as pool:
-            for _ in tqdm.tqdm(pool.imap_unordered(self.worker,
-                                                   self.task_list),
-                               total=len(self.task_list), unit='test'):
+            for _ in pool.imap_unordered(self.worker, self.task_list):
                 pass
 
     def get_reports(self):


### PR DESCRIPTION
tdqm hides the logs/content with a progress bar. When failures occur, which is rather common in this repository, tqdm makes debugging complicated. This PR removes the usage of tqdm.