### PR TITLE
Fix prepare enviromnent step in the CI

### DIFF
--- a/conf/requirements.txt
+++ b/conf/requirements.txt
@@ -7,6 +7,7 @@ pandas
 pkgconfig
 pytest
 python-constraint
+python-sat==0.1.7.dev19
 pyyaml
 requests
 simplejson


### PR DESCRIPTION
Pin the python-sat version to 0.1.7.dev19 to resolve problems with preparing a working environment in the CI.