### PR TITLE
ci: Use verbose script for getting RapidWright JAR link

### DIFF
--- a/.github/scripts/get_rapidwright_link.sh
+++ b/.github/scripts/get_rapidwright_link.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+CURL_RESPONSE="$(curl -s --retry 5 --retry-delay 10 https://api.github.com/repos/Xilinx/RapidWright/releases/latest)"
+RAPIDWRIGHT_JAR_LINK="$(echo "$CURL_RESPONSE" | grep "browser_download_url.*_jars.zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")"
+
+if [ "$RAPIDWRIGHT_JAR_LINK" == "" ]; then
+	echo "Error while obtaining RapidWright JAR Link" >&2
+	echo "curl response: $CURL_RESPONSE" >&2
+	exit 1
+fi
+
+echo "link=$RAPIDWRIGHT_JAR_LINK"

--- a/.github/workflows/Suite.yml
+++ b/.github/workflows/Suite.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y curl wget
-          echo "link=$(curl -s https://api.github.com/repos/Xilinx/RapidWright/releases/latest | grep "browser_download_url.*_jars.zip" | cut -d : -f 2,3 | tr -d \" | tr -d " ")" >> $GITHUB_OUTPUT
+          ./.github/scripts/get_rapidwright_link.sh | tee -a $GITHUB_OUTPUT
 
       - name: Generate Matrix
         id: generate


### PR DESCRIPTION
This PR adds a dedicated script for obtaining the RapidWright JAR link. The script has the following advantages over the previous approach:

- retries curl requests on failure
- checks whether the obtained link is valid 
- exits with the error code and additional debug info on failure