### PR TITLE
ci: Prevent skipping errors in pipes

### DIFF
--- a/.github/workflows/Suite.yml
+++ b/.github/workflows/Suite.yml
@@ -12,6 +12,10 @@ on:
 env:
   timeout: 7200
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
 
   Matrix:


### PR DESCRIPTION
Adding bash as a default shell enforces `set -eo pipefail`, which prevents skipping errors in pipes.

More info is available in the [documentation of GitHub Actions](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell)
Link to a CI [job](https://github.com/chipsalliance/fpga-tool-perf/actions/runs/3830944664/jobs/6519511200#step:4:55) showing that the solution works.