### PR TITLE
Remove manual installation of tbb library after updating nextpnr-fpga-interchange conda package

### DIFF
--- a/.github/scripts/install.sh
+++ b/.github/scripts/install.sh
@@ -31,8 +31,7 @@ DEBIAN_FRONTEND=noninteractive $(command -v sudo) apt install -qq -y --no-instal
   default-jdk \
   xz-utils \
   libtinfo5 \
-  locales \
-  libtbb2
+  locales
 echo '::endgroup::'
 
 echo '::group::Locales setup'


### PR DESCRIPTION
After adding tbb library as a run dependency to conda, manual installation of the package in CI is no longer required.

Related to https://github.com/chipsalliance/fpga-tool-perf/pull/536#issuecomment-1369965277