### PR TITLE
ci: pin gcloud to 413.0.0-0

### DIFF
--- a/.github/workflows/Suite.yml
+++ b/.github/workflows/Suite.yml
@@ -496,7 +496,8 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
           curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
           apt update -qqy
-          apt install -qqy google-cloud-cli
+          # TODO: remove version pindown after https://github.com/GoogleCloudPlatform/gsutil/issues/1663 has been resolved
+          apt install -qqy google-cloud-cli=413.0.0-0
 
       - uses: actions/download-artifact@v3
 


### PR DESCRIPTION
This is a temporary workaround for a regression in gsutil which causes multithreaded uploads to fail if the `storage.buckets.get` permission is missing on the caller IAM.
The regression is further documented in the release notes: https://cloud.google.com/storage/docs/release-notes#January_19_2023

This commit should be reverted once the regression has been fixed.

Internal-tag: [#41010]
Signed-off-by: Adam Olech <aolech@antmicro.com>