### PR TITLE
Fix nextpnr-fpga_interchange-experimental-single-thread toolchain

### DIFF
--- a/.github/scripts/build_nextpnr_fpga_interchange.sh
+++ b/.github/scripts/build_nextpnr_fpga_interchange.sh
@@ -27,7 +27,7 @@ update-ca-certificates
 echo '::endgroup::'
 
 echo '::group::Building nextpnr-fpga_interchange'
-if [ "$1" == "no_threads" ]; then
+if [ "$1" == "single_thread" ]; then
 THREADS="-DUSE_THREADS=OFF"
 fi
 cd ./third_party/nextpnr

--- a/.github/scripts/build_nextpnr_fpga_interchange.sh
+++ b/.github/scripts/build_nextpnr_fpga_interchange.sh
@@ -28,7 +28,7 @@ echo '::endgroup::'
 
 if [ "$1" == "single_thread" ]; then
     VERSION="(single-thread)"
-    THREADS="-DUSE_THREADS=OFF"
+    THREADS="-DCMAKE_CXX_FLAGS='-DNPNR_DISABLE_THREADS'"
 fi
 
 echo "::group::Building nextpnr-fpga_interchange ${VERSION}"

--- a/.github/scripts/build_nextpnr_fpga_interchange.sh
+++ b/.github/scripts/build_nextpnr_fpga_interchange.sh
@@ -26,10 +26,12 @@ echo '::group::Updating CA certificates'
 update-ca-certificates
 echo '::endgroup::'
 
-echo '::group::Building nextpnr-fpga_interchange'
 if [ "$1" == "single_thread" ]; then
-THREADS="-DUSE_THREADS=OFF"
+    VERSION="(single-thread)"
+    THREADS="-DUSE_THREADS=OFF"
 fi
+
+echo "::group::Building nextpnr-fpga_interchange ${VERSION}"
 cd ./third_party/nextpnr
 cmake . ${THREADS} -DARCH=fpga_interchange -DRAPIDWRIGHT_PATH=`realpath ../RapidWright` -DINTERCHANGE_SCHEMA_PATH=`realpath ../fpga-interchange-schema`
 make

--- a/toolchains/nextpnr.py
+++ b/toolchains/nextpnr.py
@@ -711,6 +711,7 @@ class NextPnrInterchangeExperimentalNoSynthSingleThread(
 
     def configure(self):
         super().configure()
+        self.tool_options['nextpnr_options'] = self.options + ['--threads=1']
         self.tool_options['binary_path'] = self.toolchain_bin
 
 


### PR DESCRIPTION
This PR contains fixes for building the nextpnr-fpga_interchange experimental single-thread toolchain. Without them, the toolchain is built exactly in the same way as the experimental version (with multithreading enabled)