### PR TITLE
Fix usage of lstrip and rstrip

### DIFF
--- a/toolchains/icestorm.py
+++ b/toolchains/icestorm.py
@@ -24,6 +24,7 @@ import edalize
 
 from toolchains.toolchain import Toolchain
 from utils.utils import Timed, have_exec, get_yosys_resources, get_file_dict
+from utils.utils import removeprefix
 
 YOSYS_REGEXP = re.compile("(Yosys [a-z0-9+.]+) (\(git sha1) ([a-z0-9]+),.*")
 
@@ -182,7 +183,7 @@ class NextpnrIcestorm(Icestorm):
         self.toolchain = "nextpnr-ice40"
 
     def run(self):
-        self.device = self.device.lower().lstrip("ice40")
+        self.device = removeprefix(self.device.lower(), "ice40")
         self.package = self.package.lower().rstrip("i")
 
         args = ''

--- a/toolchains/nextpnr.py
+++ b/toolchains/nextpnr.py
@@ -26,6 +26,7 @@ import sys
 
 from toolchains.toolchain import Toolchain
 from utils.utils import Timed, have_exec, get_file_dict, get_vivado_max_freq, get_yosys_resources
+from utils.utils import removeprefix, removesuffix
 
 YOSYS_REGEXP = re.compile("(Yosys [a-z0-9+.]+) (\(git sha1) ([a-z0-9]+),.*")
 
@@ -259,6 +260,10 @@ class NextpnrGeneric(Toolchain):
         assert False, "No run time found for yosys."
 
     def get_nextpnr_runtimes(self, logfile):
+        def parse_time(string, prefix):
+            string = removeprefix(string, prefix)
+            return removesuffix(string, "s")
+
         log = dict()
 
         placement = 0.0
@@ -270,7 +275,7 @@ class NextpnrGeneric(Toolchain):
                 if len(l) == 0:
                     continue
 
-                l = l.lstrip("Info: ")
+                l = removeprefix(l, "Info: ")
                 heap_placer_string = "HeAP Placer Time: "
                 sa_placer_string = "SA placement time "
 
@@ -278,16 +283,16 @@ class NextpnrGeneric(Toolchain):
                 router2_string = "Router2 time "
 
                 if heap_placer_string in l:
-                    time = float(l.lstrip(heap_placer_string).rstrip("s"))
+                    time = float(parse_time(l, heap_placer_string))
                     placement += time
                 elif sa_placer_string in l:
-                    time = float(l.lstrip(sa_placer_string).rstrip("s"))
+                    time = float(parse_time(l, sa_placer_string))
                     placement += time
                 elif router1_string in l:
-                    time = float(l.lstrip(router1_string).rstrip("s"))
+                    time = float(parse_time(l, router1_string))
                     routing += time
                 elif router2_string in l:
-                    time = float(l.lstrip(router2_string).rstrip("s"))
+                    time = float(parse_time(l, router2_string))
                     routing += time
 
         log["place"] = placement

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -161,3 +161,17 @@ def safe_get_dict_value(dict, key, default):
 
 def get_file_dict(file_name, file_type):
     return dict(name=os.path.realpath(file_name), file_type=file_type)
+
+
+def removeprefix(string, prefix):
+    if string.startswith(prefix):
+        return string[len(prefix):]
+    else:
+        return string[:]
+
+
+def removesuffix(string, suffix):
+    if suffix and string.endswith(suffix):
+        return string[:-len(suffix)]
+    else:
+        return string[:]


### PR DESCRIPTION
Recently we noticed that part of the instability in nextpnr-fpga_interchange toolchains was caused by incorrect usage of `str.lstrip()` and `str.rstrip()` functions during log parsing.

This PR changes the wrong occurrences of those function calls to `removeprefix()` and `removesuffix()` functions respectively. The functions from the python library (`str.removeprefix()`, `str.removesuffix()`) are not used because they were introduced in Python 3.9 and we want to be compatible with older versions of python.

The incorrect usage of `str.lstrip()` and `str.rstrip()` led to incorrect calculations of execution times in the `nextpnr-fpga_interchange` toolchain (most notably in the routing time results).