### PR TITLE
Pin type of spawned GCP machines

### DIFF
--- a/.github/workflows/Pages.yml
+++ b/.github/workflows/Pages.yml
@@ -13,6 +13,7 @@ jobs:
     container: ubuntu:focal-20221130
     env:
       GHA_SA: gh-sa-fpga-tool-perf-ci
+      GHA_MACHINE_TYPE: "n2-standard-4"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/Suite.yml
+++ b/.github/workflows/Suite.yml
@@ -11,6 +11,7 @@ on:
 
 env:
   timeout: 7200
+  GHA_MACHINE_TYPE: "n2-standard-4"
 
 defaults:
   run:

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -9,6 +9,9 @@ jobs:
     container: ubuntu:focal-20221130
     runs-on: [self-hosted, Linux, X64]
 
+    env:
+      GHA_MACHINE_TYPE: "n2-standard-4"
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Pin the type of spawned GCP machines to make sure that we use the same type of devices to measure the performance.