### PR TITLE
doc(results): `make fetch` to `make preprocess`

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -13,6 +13,6 @@ make env
 To generate the HTML pages to visualize the results run:
 
 ```
-make fetch
+make preprocess
 make build
 ```


### PR DESCRIPTION
It seems like the documentation may be out dated, as there is no rule for `fetch` in `Makefile` now. I believe you mean `preprocess`.