### PR TITLE
feat(visual): toggle toolchain visibility in performance visualization

### DIFF
--- a/results/html/index.html
+++ b/results/html/index.html
@@ -76,6 +76,7 @@
 <script charset="utf-8">
 
 var visible_elem = null;
+var visible_chart_ids = [];
 
 // sets visibility of an element with the w3-hide class by appending/removing w3-show class
 function setVisibility(elem, on) {
@@ -183,7 +184,8 @@ function selectStat(elem_id, device, project) {
 }
 
 function LineChart(canvas_name, title, unitstr, labels, datasets, legend) {
-  return new Chart(document.getElementById(canvas_name), {
+    visible_chart_ids.push(canvas_name);
+  const myChart = new Chart(document.getElementById(canvas_name), {
     type: 'line',
     data: {
       labels: labels,
@@ -205,7 +207,15 @@ function LineChart(canvas_name, title, unitstr, labels, datasets, legend) {
           },
         },
         legend: {
-          display: legend,
+          display: true,
+            onClick : (t, e, i) => {
+                const n = e.datasetIndex
+                    , o = i.chart;
+                visible_chart_ids.forEach(id => {
+                    const chart = Chart.getChart(document.getElementById(id));
+                    chart.isDatasetVisible(n)? chart.hide(n) : chart.show(n);
+                })
+            }
         },
         zoom: {
           zoom: {
@@ -243,6 +253,7 @@ function LineChart(canvas_name, title, unitstr, labels, datasets, legend) {
       }
     }
   });
+  return myChart;
 }
 
 function handleSearchQuery() {
@@ -259,6 +270,7 @@ function handleSearchQuery() {
   var device = params.get('device');
   var project = params.get('project');
   if (elem_id) {
+      visible_chart_ids = []
     selectStat(elem_id, device, project);
     selectGraph("runtime", device, project)
   }

--- a/results/result_entry.py
+++ b/results/result_entry.py
@@ -165,7 +165,7 @@ def get_entries(json_data: dict, project: str):
         results['board'], results['toolchain'], results['max_freq'],
         results['maximum_memory_use'], results['resources'],
         results['runtime'], wirelength, status, results['toolchain'],
-        results['versions'], results['family'], results['device']
+        results['versions'] if 'versions' in results else {}, results['family'] if 'family' in results else {}, results['device']
     )
     for board, toolchain_dict, max_freq, max_mem_use, resources, runtime, \
             wirelength, status, toolchain, versions, family, device in zipped:


### PR DESCRIPTION
Regarding this issue #402 

First, the `json.gz` file you give me will fail the `make build` process because some records do not have the property `versions` or `family`. Therefore, I added the following codes:
```python
results['versions'] if 'versions' in results else {}, results['family'] if 'family' in results else {}, results['device']
```

Second, I tried to achieve the functionality to toggle the visibility by clicking the LINES instead of the legend, but I failed. I made a workaround to toggle by clicking the legend.

Something like this in the chart configuration won't work
```js
interaction: {
        mode: 'index',
        intersect: false,
        axis: 'x',
        onHover: function (event, chartElement) {
          console.log("hover"); // no log
        },
        onClick: function (event, chartElement) {
          console.log("click");  // no log either
        }
      }
```

Something like this won't work either
```js
function clickHandler(click){
    const points = myChart.getElementsAtEventForMode(click, 'nearest', { intersect: true}, true);
    console.log(points); // always an empty array
}
myChart.canvas.onclick = clickHandler;
```

Hope you find the workaround acceptable.
